### PR TITLE
Support ohai > 7

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 #
 
 PLUGIN_PATH = node['vagrant-ohai']['plugin_path']
-FILE_MODIFIER = Ohai::VERSION.split('.')[0] == '7' ? '-ohai7' : ''
+FILE_MODIFIER = Ohai::VERSION.split('.')[0].to_i >= 7 ? '-ohai7' : ''
 
 Ohai::Config[:plugin_path] << PLUGIN_PATH
 Chef::Log.info("vagrant ohai plugins will be at: #{PLUGIN_PATH}")

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,14 +32,14 @@ directory PLUGIN_PATH do
   recursive true
 end.run_action(:create)
 
-cookbook_file "#{File.join(PLUGIN_PATH, 'README.md')}" do
+cookbook_file File.join(PLUGIN_PATH, 'README.md') do
   source 'README.md'
   owner 'root'
   group 'root'
   mode 0755
 end
 
-cf = cookbook_file "#{File.join(PLUGIN_PATH, 'vagrant-net.rb')}" do
+cf = cookbook_file File.join(PLUGIN_PATH, 'vagrant-net.rb') do
   source "vagrant-net#{FILE_MODIFIER}.rb"
   owner 'root'
   group 'root'


### PR DESCRIPTION
The original change to support ohai 7 plugins didn't take ohai versions higher than 7 into account. This fixes it, and cleans up the recipe a bit.

I will prepare a PR for the top upstream (tknerr/cookbooks-vagrant-ohai), but for now this PR is the path of least resistance to get this working.
